### PR TITLE
Today.Storayboard 구현(1)

### DIFF
--- a/OneDayOneAnswer/OneDayOneAnswer/Base.lproj/Today.storyboard
+++ b/OneDayOneAnswer/OneDayOneAnswer/Base.lproj/Today.storyboard
@@ -25,22 +25,42 @@
                                     <segue destination="MqJ-Lu-PPC" kind="show" id="RC4-Nv-6L6"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="2020년 05월 11일" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NWb-9S-QrQ">
-                                <rect key="frame" x="140" y="83" width="129" height="21"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwe-hO-ItZ">
+                                <rect key="frame" x="356" y="58" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="저장"/>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="yyyy년 MM월 dd일" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NWb-9S-QrQ">
+                                <rect key="frame" x="107" y="53" width="200" height="40"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwe-hO-ItZ">
-                                <rect key="frame" x="348" y="58" width="46" height="30"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="aIX-Uy-61t">
+                                <rect key="frame" x="32" y="190" width="353" height="330"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                            </button>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <inset key="scrollIndicatorInsets" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="잠시 생각해보면서 나를 알아가는시간을 완성해주세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MEd-Gw-VZM">
+                                <rect key="frame" x="43" y="210" width="336" height="20"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
+                    <connections>
+                        <outlet property="labelDate" destination="NWb-9S-QrQ" id="o7e-5R-KdH"/>
+                        <outlet property="labelPlaceHolder" destination="MEd-Gw-VZM" id="Lws-uB-tg3"/>
+                        <outlet property="textViewAnswer" destination="aIX-Uy-61t" id="O1c-gR-E5P"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/OneDayOneAnswer/OneDayOneAnswer/TodayViewController.swift
+++ b/OneDayOneAnswer/OneDayOneAnswer/TodayViewController.swift
@@ -8,13 +8,41 @@
 
 import UIKit
 
-class TodayViewController: UIViewController {
-
+class TodayViewController: UIViewController, UITextViewDelegate {
+    
+    @IBOutlet var labelDate: UILabel!
+    @IBOutlet var textViewAnswer: UITextView!
+    @IBOutlet var labelPlaceHolder: UILabel!
+    
+    func DateAsString() -> String {
+        let today = Date() // 현재시간을 가져옴
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 dd일"
+        let dateString = formatter.string(from: today)
+        return dateString
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        
+        labelDate.textAlignment = .center
+        labelDate.text = String(DateAsString())
+        
+        textViewAnswer.delegate = self
+        textViewAnswer.layer.borderWidth = 1.0
+        textViewAnswer.layer.borderColor = UIColor.darkGray.cgColor
+        textViewAnswer.layer.cornerRadius = 10 // 모서리 둥글게
+        textViewAnswer.textContainerInset = UIEdgeInsets(top: 20, left: 5, bottom: 20, right: 5)
     }
-
-
+    
+    func textViewDidChange(_ textViewAnswer: UITextView) {
+        labelPlaceHolder.isHidden = !textViewAnswer.text.isEmpty
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+    
 }
 

--- a/OneDayOneAnswer/OneDayOneAnswer/TodayViewController.swift
+++ b/OneDayOneAnswer/OneDayOneAnswer/TodayViewController.swift
@@ -22,6 +22,13 @@ class TodayViewController: UIViewController, UITextViewDelegate {
         return dateString
     }
     
+    func setTextView() {
+        self.textViewAnswer.layer.borderWidth = 1.0
+        self.textViewAnswer.layer.borderColor = UIColor.darkGray.cgColor
+        self.textViewAnswer.layer.cornerRadius = 10 // 모서리 둥글게
+        self.textViewAnswer.textContainerInset = UIEdgeInsets(top: 20, left: 5, bottom: 20, right: 5)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
@@ -30,10 +37,7 @@ class TodayViewController: UIViewController, UITextViewDelegate {
         labelDate.text = String(DateAsString())
         
         textViewAnswer.delegate = self
-        textViewAnswer.layer.borderWidth = 1.0
-        textViewAnswer.layer.borderColor = UIColor.darkGray.cgColor
-        textViewAnswer.layer.cornerRadius = 10 // 모서리 둥글게
-        textViewAnswer.textContainerInset = UIEdgeInsets(top: 20, left: 5, bottom: 20, right: 5)
+        setTextView()
     }
     
     func textViewDidChange(_ textViewAnswer: UITextView) {


### PR DESCRIPTION
Today.Storayboard 구현 (#10) 관련
금일 작업분 코드리뷰 요청드립니다

<p align="center"><img src="https://user-images.githubusercontent.com/60066472/80362830-4457f400-88be-11ea-8c9e-2435f38f07b5.gif" width="250"></p> 

### 0. 추가한 객체
- `labelDate` : 오늘날짜 표시
- `textViewAnswer` : 답변 작성할 칸
- `labelPlaceHolder` : 답변 작성할 칸에 띄워둘 placeholder(hint)
<br>

### 1. 작성날짜(오늘날짜) 표시하기
- Date() 로 현재날짜를 가져옴
- DateFormatter()로 "yyyy년 MM월 dd일" 형태로 표시
<br>

### 2. placeholder 만들기
- textView는 placeholder를 따로 구현해야해서 별도로 label 생성 `labelPlaceHolder`
- `isEmpty`와 `isHidden`을 이용하여 작성한 내용이 없으면  답변작성가이드 띄우고 작성한 내용이 있으면 답변작성가이드 없앰
<br>

### 3. 답변작성 텍스트뷰 외 누르면 키보드 띄우기
- textView 터치 시 자동으로 팝업
- 만약 뜨지 않는다면 시뮬레이터 - Hardware - Keyboard - Toggle Software Keyboard
<br>

### 4. 텍스트뷰 외 터치 시 키보드 감추기
- override func touchesBegan()로 구현
<br>

### 5. 기타
- placeholder, textview 폰트사이즈 : 16pt로 설정함 (필요시 변경)
- textview 테두리 적용, 모서리 둥글게 변경함
- 시뮬레이터 녹화하는 방법 📷 
    - 터미널에 입력 `xcrun simctl io booted recordVideo ~/simulator.mov`
    - 구글에 입력 `convert mov to gif`