### PR TITLE
저장할때 15바이트 이하는 저장이 제대로 안되는 문제 해결

### DIFF
--- a/OneDayOneAnswer/OneDayOneAnswer/DataBase/SqliteDataBase.swift
+++ b/OneDayOneAnswer/OneDayOneAnswer/DataBase/SqliteDataBase.swift
@@ -15,6 +15,9 @@ class SqliteDataBase: DataBase {
     static let dbName: String = "db.sqlite"
     static let tableName: String = "article"
     
+    static let SQLITE_STATIC = unsafeBitCast(0, to: sqlite3_destructor_type.self)
+    static let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    
     private var sqlite: OpaquePointer?
     
     private init() {
@@ -137,10 +140,10 @@ class SqliteDataBase: DataBase {
             print(errmsg)
             return false
         }
-        sqlite3_bind_text(statement, 1, dateToStr(article.date, "yyyy-MM-dd HH:mm:ss"), -1, nil)
-        sqlite3_bind_text(statement, 2, article.question, -1, nil)
-        sqlite3_bind_text(statement, 3, article.answer, -1, nil)
-        sqlite3_bind_text(statement, 4, article.imagePath, -1, nil)
+        sqlite3_bind_text(statement, 1, dateToStr(article.date, "yyyy-MM-dd HH:mm:ss"), -1, SqliteDataBase.SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 2, article.question, -1, SqliteDataBase.SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 3, article.answer, -1, SqliteDataBase.SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 4, article.imagePath, -1, SqliteDataBase.SQLITE_TRANSIENT)
         guard sqlite3_step(statement) == SQLITE_DONE else {
             let errmsg: String = String(cString: sqlite3_errmsg(self.sqlite)!)
             print(errmsg)
@@ -183,7 +186,7 @@ class SqliteDataBase: DataBase {
             return nil
         }
         
-        sqlite3_bind_text(statement, 1, dateToStr(date), -1, nil)
+        sqlite3_bind_text(statement, 1, dateToStr(date), -1, SqliteDataBase.SQLITE_TRANSIENT)
         
         guard sqlite3_step(statement) == SQLITE_ROW else {
             let errmsg: String = String(cString: sqlite3_errmsg(self.sqlite))
@@ -234,9 +237,9 @@ class SqliteDataBase: DataBase {
             print(errmsg)
             return false
         }
-        
-        sqlite3_bind_text(statement, 1, article.answer, -1, nil)
-        sqlite3_bind_text(statement, 2, article.imagePath, -1, nil)
+
+        sqlite3_bind_text(statement, 1, article.answer, -1, SqliteDataBase.SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 2, article.imagePath, -1, SqliteDataBase.SQLITE_TRANSIENT)
         sqlite3_bind_int(statement, 3, Int32(article.id))
         
         guard sqlite3_step(statement) == SQLITE_DONE else {


### PR DESCRIPTION
sqlite bind 사용 시 SQLITE_TRANSIENT 추가하여 해결

https://stackoverflow.com/questions/28142226/sqlite-for-swift-is-unstable

### 리뷰어 배정(PR일 기준)
- __홀수일__ : 재두 > 미혜 > 준서 > 재두
    - __재두__ 는 __미혜__ 의 코드를 리뷰한다
    - __미혜__ 는 __준서__ 의 코드를 리뷰한다
    - __준서__ 는 __재두__ 의 코드를 리뷰한다
    
- __짝수일__ : 재두 < 미혜 < 준서 < 재두
    - __재두__ 는 __준서__ 의 코드를 리뷰한다
    - __준서__ 는 __미혜__ 의 코드를 리뷰한다
    - __미혜__ 는 __재두__ 의 코드를 리뷰한다
